### PR TITLE
Bump to later versions of i2c library to support nodejs 10 and 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,9 @@
 		"nodes": {
 			"pca9685": "pca9685.js"
 		}
+	},
+	"dependencies": {
+		"pca9685": "~4.0.3",
+		"i2c-bus": "^5.x.x"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,5 @@
 		"nodes": {
 			"pca9685": "pca9685.js"
 		}
-	},
-	"dependencies": {
-		"pca9685": "~4.0.3",
-		"i2c-bus": "~4.0.9"
 	}
 }


### PR DESCRIPTION
Hi as you are the owner of the main node-red-contrib-pca9685 package - are you able to accept a PR to bump the underlying i2c library to later (or better still latest) version so that the node will install on nodejs10 and 12 ? And then republish to npm of course... Many thanks