### PR TITLE
Fix '0' is not being accepted as I2C device number

### DIFF
--- a/pca9685.js
+++ b/pca9685.js
@@ -29,10 +29,15 @@ module.exports = function(RED) {
     // The Server Definition - this opens (and closes) the connection
     function pca9685Node(config) {
         RED.nodes.createNode(this, config);
-        
+
         // node configuration
+	var deviceNumber = parseInt(config.deviceNumber);
+        if (isNaN(deviceNumber)) {
+            deviceNumber = 1;
+        }
+	    
         var options = {
-            i2c: i2cBus.openSync(parseInt(config.deviceNumber) || 1),
+            i2c: i2cBus.openSync(deviceNumber),
             address: parseInt(config.address) || 0x40,
             frequency: parseInt(config.frequency) || 50,
             debug: debugOption


### PR DESCRIPTION
The current version of node-red-contrib-pca9685 does not allow use of '0' as I2C device number, because on the line 35 `parseInt(config.deviceNumber) || 1` evaluates to 1 when `config.deviceNumber` is equal to '0'.